### PR TITLE
Change to absolute pathing to let pytest run from subdirectories

### DIFF
--- a/src/mirrulations/config.py
+++ b/src/mirrulations/config.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 
 FORMAT = '%(asctime)-15s %(clientip)s %(user)-8s %(message)s'
 logging.basicConfig(filename='client.log', format=FORMAT)
@@ -17,7 +18,8 @@ def read_value(value):
     logger.info('Reading config file...')
     try:
         logger.debug("Assign Variable: %s", 'read_value: loading json from config', extra=d)
-        contents = json.loads(open("./config.json","r").read())
+        configurationpath = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../config.json")
+        contents = json.loads(open(configurationpath, "r").read())
         logger.debug("Variable Success: %s", 'read_value: found json from config', extra=d)
         logger.info('Config file read successful...')
     except:

--- a/tests/mirrulations_tests/test_doc_filter.py
+++ b/tests/mirrulations_tests/test_doc_filter.py
@@ -6,7 +6,7 @@ import fakeredis
 import mirrulations.doc_filter as df
 
 
-PATH = 'tests/test_files/'
+PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../tests/test_files/")
 
 
 def setUp():

--- a/tests/mirrulations_tests/test_docs_filter.py
+++ b/tests/mirrulations_tests/test_docs_filter.py
@@ -8,7 +8,7 @@ from mirrulations.redis_manager import RedisManager
 from ast import literal_eval
 import os
 
-PATH = 'tests/test_files/'
+PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../tests/test_files/")
 
 r = RedisManager(redis.Redis())
 

--- a/tests/mirrulations_tests/test_endpoints.py
+++ b/tests/mirrulations_tests/test_endpoints.py
@@ -5,7 +5,10 @@ from mirrulations.endpoints import *
 import mirrulations.endpoints as endpoints
 import mock
 import json
+import os
 from ast import literal_eval
+
+PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../test_files/filename.txt")
 
 version = 'v1.3'
 @pytest.fixture
@@ -94,7 +97,7 @@ def test_generate_json():
 
 @mock.patch('mirrulations.endpoints.process_docs')
 def test_return_docs_call_success(docs, client):
-    result = client.post("/return_docs", data={'file':open('tests/test_files/filename.txt', 'rb'), 'json':json.dumps(make_json())})
+    result = client.post("/return_docs", data={'file':open(PATH, 'rb'), 'json':json.dumps(make_json())})
     assert result.status_code == 200
 
 
@@ -105,7 +108,7 @@ def test_return_docs_no_parameter(client):
 
 @mock.patch('mirrulations.endpoints.process_doc', return_value=True)
 def test_return_doc_call_success(doc,client):
-    result = client.post('/return_doc', data={'file':open('tests/test_files/filename.txt', 'rb'), 'json':json.dumps(make_json())})
+    result = client.post('/return_doc', data={'file':open(PATH, 'rb'), 'json':json.dumps(make_json())})
     assert result.status_code == 200
 
 
@@ -115,7 +118,7 @@ def test_return_doc_no_file_parameter(client):
 
 
 def test_return_doc_no_json_parameter(client):
-    result = client.post('/return_doc', data=dict(file=open('tests/test_files/filename.txt', 'rb')))
+    result = client.post('/return_doc', data=dict(file=open(PATH, 'rb')))
     assert result.status_code == 400
 
 

--- a/tests/mirrulations_web_tests/test_dirsearch.py
+++ b/tests/mirrulations_web_tests/test_dirsearch.py
@@ -2,7 +2,7 @@ import os
 from mirrulations_web import dir_search as ds
 
 PATH = os.getenv("HOME")+"/regulations_data/"
-TEMPATH = "tests/test_files/regulations-data/"
+TEMPATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "../../tests/test_files/regulations-data/")
 
 # CURRENTLY SERVER ONLY TEST
 # def test_search_document():


### PR DESCRIPTION
There were relative paths that were set up in tests that restricted the use of running `pytest` from only the parent folder /mirrulations. Changes to have absolute paths that work no matter where mirrulations is cloned to have been implemented such that `pytest` can be run from subdirectories that contain tests. This new pull request replaces my past one that had one unnecessary commit. 