### PR TITLE
Make RedisManager initialize Redis

### DIFF
--- a/src/mirrulations_server/docs_work_gen.py
+++ b/src/mirrulations_server/docs_work_gen.py
@@ -1,6 +1,5 @@
 import random
 import string
-import redis
 import mirrulations_core.api_call_management as api_manager
 import mirrulations_server.redis_manager as redis_manager
 import mirrulations_server.endpoints as endpoints
@@ -19,7 +18,7 @@ def monolith():
     :return:
     """
     url_base = 'https://api.data.gov/regulations/v3/documents.json?rpp=1000'
-    r = redis_manager.RedisManager(redis.Redis())
+    r = redis_manager.RedisManager()
     regulations_key = config.server_read_value('api key')
     current_page = 0
 

--- a/src/mirrulations_server/endpoints.py
+++ b/src/mirrulations_server/endpoints.py
@@ -1,5 +1,4 @@
 from flask import Flask, request
-import redis
 import json
 from mirrulations_server.docs_filter import process_docs
 from mirrulations_server.doc_filter import process_doc
@@ -13,7 +12,7 @@ version = 'v1.3'
 
 
 def redis_server():
-    return RedisManager(redis.Redis())
+    return RedisManager()
 
 
 @app.route('/')

--- a/src/mirrulations_server/expire.py
+++ b/src/mirrulations_server/expire.py
@@ -1,4 +1,3 @@
-import redis
 from mirrulations_server.redis_manager import RedisManager
 import time
 
@@ -9,7 +8,7 @@ def expire():
     :return:
     """
     while True:
-        RedisManager(redis.Redis()).find_expired()
+        RedisManager().find_expired()
         time.sleep(3600)
 
 

--- a/src/mirrulations_server/queue_check.py
+++ b/src/mirrulations_server/queue_check.py
@@ -1,4 +1,3 @@
-import redis
 from mirrulations_server.redis_manager import RedisManager
 
 
@@ -8,7 +7,7 @@ def queue_check(r):
 
 
 if __name__ == '__main__':
-    r = RedisManager(redis.Redis())
+    r = RedisManager()
     progress, queue = queue_check(r)
     print(progress)
     print(queue)

--- a/src/mirrulations_server/redis_manager.py
+++ b/src/mirrulations_server/redis_manager.py
@@ -1,4 +1,3 @@
-from ast import literal_eval
 from redis import Redis
 import redis_lock
 import json
@@ -25,8 +24,8 @@ class RedisManager:
             if item_from_queue is None:
                 work = {'type': 'none'}
             else:
-                work = literal_eval(item_from_queue.decode('utf-8'))
-                self.r.hset('progress', get_curr_time(), json.dumps(work))
+                work = json.loads(item_from_queue)
+                self.r.hset('progress', get_curr_time(), str(work))
             return work
 
     def add_to_queue(self, work):
@@ -208,7 +207,7 @@ class RedisManager:
 
             for key in key_list:
                 json_info = self.get_specific_job_from_progress_no_lock(key)
-                info = literal_eval(json_info)
+                info = json.loads(json_info)
 
                 if info['job_id'] == job_id:
                     return key.decode('utf-8')
@@ -224,7 +223,7 @@ class RedisManager:
 
         for key in key_list:
             json_info = self.get_specific_job_from_progress_no_lock(key)
-            info = literal_eval(json_info)
+            info = json.loads(json_info)
             if info['job_id'] == job_id:
                 return key.decode('utf-8')
         return -1

--- a/src/mirrulations_server/redis_manager.py
+++ b/src/mirrulations_server/redis_manager.py
@@ -1,15 +1,16 @@
 from ast import literal_eval
+from redis import Redis
 import redis_lock
 import json
 import time
 
 
 class RedisManager:
-    def __init__(self, database):
+    def __init__(self):
         """
         Initialize the database and create the lock
         """
-        self.r = database
+        self.r = Redis()
         reset_lock(self.r)
         self.lock = set_lock(self.r)
 

--- a/src/mirrulations_server/redis_manager.py
+++ b/src/mirrulations_server/redis_manager.py
@@ -25,7 +25,7 @@ class RedisManager:
                 work = {'type': 'none'}
             else:
                 work = json.loads(item_from_queue)
-                self.r.hset('progress', get_curr_time(), str(work))
+                self.r.hset('progress', get_curr_time(), item_from_queue)
             return work
 
     def add_to_queue(self, work):

--- a/src/mirrulations_server/single_call.py
+++ b/src/mirrulations_server/single_call.py
@@ -6,7 +6,7 @@ import mirrulations_server.endpoints as endpoints
 
 redis.Redis().flushdb()
 
-r = redis_manager.RedisManager(redis.Redis())
+r = redis_manager.RedisManager()
 
 docs_work = [''.join(random.choice(string.ascii_uppercase + string.digits)
                      for _ in range(16)), "docs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from fakeredis import FakeRedis
+from fakeredis import FakeRedis, FakeServer
 import mock
 import pytest
 import random
@@ -46,11 +46,13 @@ def mock_web_config():
         yield f
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(autouse=True)
 def mock_redis_manager():
 
+    fakeredis_server = FakeServer()
+
     def mock_init(self):
-        self.r = FakeRedis()
+        self.r = FakeRedis(server=fakeredis_server)
         reset_lock(self.r)
         self.lock = set_lock(self.r)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,12 @@
+from fakeredis import FakeRedis
 import mock
 import pytest
 import random
 import string
+
+from mirrulations_server.redis_manager import RedisManager,\
+                                              set_lock,\
+                                              reset_lock
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -39,3 +44,15 @@ def mock_web_config():
     with mock.patch('mirrulations_core.config.web_read_value',
                     side_effect=lambda v: fake_config_dictionary[v]) as f:
         yield f
+
+
+@pytest.fixture(scope='session', autouse=True)
+def mock_redis_manager():
+
+    def mock_init(self):
+        self.r = FakeRedis()
+        reset_lock(self.r)
+        self.lock = set_lock(self.r)
+
+    with mock.patch.object(RedisManager, '__init__', mock_init):
+        yield RedisManager()

--- a/tests/mirrulations_acceptance_tests/test_server.py
+++ b/tests/mirrulations_acceptance_tests/test_server.py
@@ -1,0 +1,50 @@
+import pytest
+from mirrulations_server.endpoints import app
+from mirrulations_server.redis_manager import RedisManager
+import json
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    yield app.test_client()
+
+
+def test_root_gives_empty_json(client):
+    result = client.get('/')
+    assert b'{}' == result.data
+
+
+def test_when_one_job_in_db_then_job_returned_by_get_work(client):
+    rm = RedisManager()
+    rm.add_to_queue(json.dumps({'job_id': "1234",'type': "docs",'data': ["Url1"],'version': "0.5"}))
+
+    result = client.get('/get_work?client_id=asdf')
+
+    assert b'{"job_id": "1234", "type": "docs", "data": ["Url1"], "version": "0.5"}' == result.data
+    assert rm.does_job_exist_in_progress('1234')
+
+
+def test_when_two_jobs_in_db_returned_by_get_work(client):
+    rm = RedisManager()
+    rm.add_to_queue(json.dumps({'job_id': "1234", 'type': "docs", 'data': ["Url1"], 'version': "0.5"}))
+    rm.add_to_queue(json.dumps({'job_id': "3456", 'type': "docs", 'data': ["Url2"], 'version': "0.5"}))
+
+    result = client.get('/get_work?client_id=asdf')
+    result_two = client.get('/get_work?client_id=asdf')
+
+    assert b'{"job_id": "1234", "type": "docs", "data": ["Url1"], "version": "0.5"}' == result.data
+    assert b'{"job_id": "3456", "type": "docs", "data": ["Url2"], "version": "0.5"}' == result_two.data
+    assert rm.does_job_exist_in_progress('1234')
+    assert rm.does_job_exist_in_progress('3456')
+
+def test_when_two_jobs_in_db_return_one_by_get_work(client):
+    rm = RedisManager()
+    rm.add_to_queue(json.dumps({'job_id': "1234", 'type': "docs", 'data': ["Url1"], 'version': "0.5"}))
+    rm.add_to_queue(json.dumps({'job_id': "3456", 'type': "docs", 'data': ["Url2"], 'version': "0.5"}))
+
+    result = client.get('/get_work?client_id=asdf')
+
+    assert b'{"job_id": "1234", "type": "docs", "data": ["Url1"], "version": "0.5"}' == result.data
+    assert rm.does_job_exist_in_progress('1234')
+    assert rm.does_job_exist_in_queue('3456')
+    assert rm.does_job_exist_in_progress('3456') is False

--- a/tests/mirrulations_core_tests/test_documents_core.py
+++ b/tests/mirrulations_core_tests/test_documents_core.py
@@ -1,6 +1,5 @@
 import json
 import mock
-import fakeredis
 from mirrulations_server.redis_manager import RedisManager
 import mirrulations_core.documents_core as dc
 
@@ -8,7 +7,7 @@ import mirrulations_core.documents_core as dc
 @mock.patch('mirrulations_server.redis_manager.reset_lock')
 @mock.patch('mirrulations_server.redis_manager.set_lock')
 def make_database(reset, lock):
-    r = RedisManager(fakeredis.FakeRedis())
+    r = RedisManager()
     r.delete_all()
     return r
 

--- a/tests/mirrulations_server_tests/test_doc_filter.py
+++ b/tests/mirrulations_server_tests/test_doc_filter.py
@@ -34,7 +34,7 @@ def savefile_tempdir():
 @mock.patch('mirrulations_server.redis_manager.reset_lock')
 @mock.patch('mirrulations_server.redis_manager.set_lock')
 def make_database(reset, lock):
-    r = RedisManager(fakeredis.FakeRedis())
+    r = RedisManager()
     r.delete_all()
     return r
 

--- a/tests/mirrulations_server_tests/test_doc_filter.py
+++ b/tests/mirrulations_server_tests/test_doc_filter.py
@@ -2,7 +2,6 @@ import pytest
 import requests_mock
 import tempfile
 import os
-import fakeredis
 import json
 import mock
 import mirrulations_server.doc_filter as df

--- a/tests/mirrulations_server_tests/test_docs_filter.py
+++ b/tests/mirrulations_server_tests/test_docs_filter.py
@@ -1,6 +1,5 @@
 import json
 import os
-import fakeredis
 import mock
 import mirrulations_server.docs_filter as dsf
 from mirrulations_server.redis_manager import RedisManager

--- a/tests/mirrulations_server_tests/test_docs_filter.py
+++ b/tests/mirrulations_server_tests/test_docs_filter.py
@@ -14,7 +14,7 @@ REGULATIONS_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
 @mock.patch('mirrulations_server.redis_manager.reset_lock')
 @mock.patch('mirrulations_server.redis_manager.set_lock')
 def make_database(reset, lock):
-    r = RedisManager(fakeredis.FakeRedis())
+    r = RedisManager()
     r.delete_all()
     return r
 

--- a/tests/mirrulations_server_tests/test_endpoints.py
+++ b/tests/mirrulations_server_tests/test_endpoints.py
@@ -1,9 +1,7 @@
 import pytest
 import requests_mock
-import mock
 import fakeredis
 import mirrulations_server.endpoints as endpoints
-from mirrulations_server.redis_manager import RedisManager
 import json
 import os
 from ast import literal_eval
@@ -12,9 +10,6 @@ PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                     "../test_files/mirrulations_files/filename.txt")
 
 version = 'v1.3'
-
-endpoints.redis_server = mock.Mock(return_value=RedisManager(
-    fakeredis.FakeRedis()))
 
 
 @pytest.fixture

--- a/tests/mirrulations_server_tests/test_queue_check.py
+++ b/tests/mirrulations_server_tests/test_queue_check.py
@@ -1,4 +1,3 @@
-import fakeredis
 import json
 from mirrulations_server.queue_check import queue_check
 from mirrulations_server.redis_manager import RedisManager

--- a/tests/mirrulations_server_tests/test_queue_check.py
+++ b/tests/mirrulations_server_tests/test_queue_check.py
@@ -5,12 +5,12 @@ from mirrulations_server.redis_manager import RedisManager
 
 
 def emptydatabase():
-    r = RedisManager(fakeredis.FakeRedis())
+    r = RedisManager()
     return r
 
 
 def make_database():
-    r = RedisManager(fakeredis.FakeRedis())
+    r = RedisManager()
     r.delete_all()
     list = json.dumps({"A": "a", "B": ["b", "c"]})
     list2 = json.dumps({"D": "d", "E": ["e", "f"]})

--- a/tests/mirrulations_server_tests/test_redis_manager.py
+++ b/tests/mirrulations_server_tests/test_redis_manager.py
@@ -9,7 +9,7 @@ import time
 @mock.patch('mirrulations_server.redis_manager.reset_lock')
 @mock.patch('mirrulations_server.redis_manager.set_lock')
 def make_database(reset, lock):
-    r = RedisManager(fakeredis.FakeRedis())
+    r = RedisManager()
     r.delete_all()
     list = json.dumps({"A": "a", "B": ["b", "c"]})
     list2 = json.dumps({"D": "d", "E": ["e", "f"]})

--- a/tests/mirrulations_server_tests/test_redis_manager.py
+++ b/tests/mirrulations_server_tests/test_redis_manager.py
@@ -1,4 +1,3 @@
-import fakeredis
 import json
 import mock
 from mirrulations_server.redis_manager import RedisManager


### PR DESCRIPTION
Not only should this make Redis only initialize in two places now (redis_manager and server main), but it also makes it easier to mock out.